### PR TITLE
ModesMixer starts Service specified directory MM2_PATH

### DIFF
--- a/rootfs/etc/services.d/modesmixer2/run
+++ b/rootfs/etc/services.d/modesmixer2/run
@@ -231,6 +231,12 @@ echo "Running: " "${MM2_BIN}" "${MM2_CMD[@]}" \
   2>&1 | stdbuf -o0 sed --unbuffered '/^$/d' | stdbuf -o0 awk '{print "[ModeSMixer2] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
 
 # shellcheck disable=SC2016
+
+# Start ModesMixer in a specified directory to save the distances.json
+if [[ -n "$MM2_PATH" ]]; then
+    cd "${MM2_PATH}"
+fi
+
 "${MM2_BIN}" "${MM2_CMD[@]}" \
   2>&1 | stdbuf -o0 sed --unbuffered '/^$/d' | stdbuf -o0 awk '{print "[ModeSMixer2] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
 

--- a/rootfs/etc/services.d/modesmixer2/run
+++ b/rootfs/etc/services.d/modesmixer2/run
@@ -230,13 +230,13 @@ set -eo pipefail
 echo "Running: " "${MM2_BIN}" "${MM2_CMD[@]}" \
   2>&1 | stdbuf -o0 sed --unbuffered '/^$/d' | stdbuf -o0 awk '{print "[ModeSMixer2] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
 
-# shellcheck disable=SC2016
 
 # Start ModesMixer in a specified directory to save the distances.json
 if [[ -n "$MM2_PATH" ]]; then
     cd "${MM2_PATH}"
 fi
 
+# shellcheck disable=SC2016
 "${MM2_BIN}" "${MM2_CMD[@]}" \
   2>&1 | stdbuf -o0 sed --unbuffered '/^$/d' | stdbuf -o0 awk '{print "[ModeSMixer2] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
 


### PR DESCRIPTION
Hi Mikenye,

the ModesMixer use a distances.json to save some Informations 
On your config the file is in : 
/run/s6/services/modesmixer2

Addd MM2_PATH to switch the Path in there modesmixer2 starts in the Service.

Kind Regards
Flightliner